### PR TITLE
Added CodeTour Watch workflow

### DIFF
--- a/.github/workflows/codetour-watch.yml
+++ b/.github/workflows/codetour-watch.yml
@@ -1,0 +1,17 @@
+name: CodeTour watch
+
+on:
+    pull_request:
+        types: [opened, edited, synchronize, reopened]
+
+jobs:
+    codetour-watch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 'Checkout source code'
+              uses: actions/checkout@v2
+
+            - name: 'Watch CodeTour changes'
+              uses: pozil/codetour-watch@v1.0.1
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've added a workflow with a [GitHub Action](https://github.com/pozil/codetour-watch) that reports code changes that could affect CodeTour content.

Waiting for CodeTour to be implemented before merging.