### PR TITLE
Map shows message when no property is selected

### DIFF
--- a/force-app/main/default/lwc/propertyMap/__tests__/data/propertyRecord.json
+++ b/force-app/main/default/lwc/propertyMap/__tests__/data/propertyRecord.json
@@ -1,0 +1,22 @@
+{
+    "apiName": "Property__c",
+    "fields": {
+        "Address__c": {
+            "displayValue": null,
+            "value": "127 Endicott St"
+        },
+        "City__c": {
+            "displayValue": null,
+            "value": "Boston"
+        },
+        "Location__Latitude__s": {
+            "displayValue": null,
+            "value": "10"
+        },
+        "Location__Longitude__s": {
+            "displayValue": null,
+            "value": "10"
+        }
+    },
+    "id": "a013h000009HEM7AAO"
+}

--- a/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
+++ b/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
@@ -27,7 +27,7 @@ describe('c-property-map', () => {
         jest.clearAllMocks();
     });
 
-    it('is render an error panel when no property is selected', () => {
+    it('renders an error panel when no property is selected', () => {
         const element = createElement('c-property-map', {
             is: PropertyMap
         });
@@ -40,7 +40,7 @@ describe('c-property-map', () => {
         });
     });
 
-    it('is render a map when a property is selected', () => {
+    it('renders a map when a property is selected', () => {
         const element = createElement('c-property-map', {
             is: PropertyMap
         });
@@ -62,6 +62,9 @@ describe('c-property-map', () => {
         });
 
         document.body.appendChild(element);
+        
+        // Simulate property selection
+        getRecordAdapter.emit(mockPropertyRecord);
 
         return Promise.resolve().then(() => {
             expect(element).toBeAccessible();

--- a/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
+++ b/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
@@ -62,7 +62,7 @@ describe('c-property-map', () => {
         });
 
         document.body.appendChild(element);
-        
+
         // Simulate property selection
         getRecordAdapter.emit(mockPropertyRecord);
 

--- a/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
+++ b/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
@@ -1,0 +1,82 @@
+import { createElement } from 'lwc';
+import PropertyMap from 'c/propertyMap';
+import { getRecord } from 'lightning/uiRecordApi';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
+
+// Realistic property record
+const mockPropertyRecord = require('./data/propertyRecord.json');
+const EXPECTED_MAP_MARKERS = [
+    {
+        location: {
+            Latitude: mockPropertyRecord.fields.Location__Latitude__s.value,
+            Longitude: mockPropertyRecord.fields.Location__Longitude__s.value
+        },
+        title: mockPropertyRecord.fields.Address__c.value
+    }
+];
+
+// Register the test wire adapter
+const getRecordAdapter = registerApexTestWireAdapter(getRecord);
+
+describe('c-property-map', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('is render an error panel when no property is selected', () => {
+        const element = createElement('c-property-map', {
+            is: PropertyMap
+        });
+
+        document.body.appendChild(element);
+
+        return Promise.resolve().then(() => {
+            const panelEl = element.shadowRoot.querySelector('c-error-panel');
+            expect(panelEl).not.toBeNull();
+        });
+    });
+
+    it('is render a map when a property is selected', () => {
+        const element = createElement('c-property-map', {
+            is: PropertyMap
+        });
+        document.body.appendChild(element);
+
+        // Simulate property selection
+        getRecordAdapter.emit(mockPropertyRecord);
+
+        return Promise.resolve().then(() => {
+            const mapEl = element.shadowRoot.querySelector('lightning-map');
+            expect(mapEl).not.toBeNull();
+            expect(mapEl.mapMarkers).toStrictEqual(EXPECTED_MAP_MARKERS);
+        });
+    });
+
+    it('is accessible when property is selected', () => {
+        const element = createElement('c-property-map', {
+            is: PropertyMap
+        });
+
+        document.body.appendChild(element);
+
+        return Promise.resolve().then(() => {
+            expect(element).toBeAccessible();
+        });
+    });
+
+    it('is accessible when property is not selected', () => {
+        const element = createElement('c-property-map', {
+            is: PropertyMap
+        });
+
+        document.body.appendChild(element);
+
+        return Promise.resolve().then(() => {
+            expect(element).toBeAccessible();
+        });
+    });
+});

--- a/force-app/main/default/lwc/propertyMap/propertyMap.html
+++ b/force-app/main/default/lwc/propertyMap/propertyMap.html
@@ -1,13 +1,20 @@
 <template>
     <lightning-card title={address} icon-name="custom:custom106">
-        <lightning-map
-            map-markers={markers}
-            zoom-level={zoomLevel}
-        ></lightning-map>
-        <template if:true={error}>
+        <template if:true={markers}>
+            <lightning-map
+                map-markers={markers}
+                zoom-level={zoomLevel}
+            ></lightning-map>
+            <template if:true={error}>
+                <c-error-panel
+                    friendly-message="Error retrieving map"
+                    errors={error}
+                ></c-error-panel>
+            </template>
+        </template>
+        <template if:false={markers}>
             <c-error-panel
-                friendly-message="Error retrieving map"
-                errors={error}
+                friendly-message="Select a property to see its location"
             ></c-error-panel>
         </template>
     </lightning-card>

--- a/force-app/main/default/lwc/propertyMap/propertyMap.js
+++ b/force-app/main/default/lwc/propertyMap/propertyMap.js
@@ -17,7 +17,7 @@ const fields = [
 export default class PropertyMap extends LightningElement {
     address;
     error;
-    markers = [];
+    markers;
     propertyId;
     subscription = null;
     zoomLevel = 14;


### PR DESCRIPTION
Product Finder shows an empty map when no property is selected:

![Screen Shot 2020-11-25 at 18 28 00](https://user-images.githubusercontent.com/5071767/100262118-01412a80-2f4c-11eb-9bab-ff2c01fec191.png)

I've replaced that with a user-friendly message to match the behavior of the property summary card:

![message](https://user-images.githubusercontent.com/5071767/100262132-03a38480-2f4c-11eb-9060-46d8a9172f0b.png)
