### PR TITLE
Removed PropertyController.getPropertyList Apex method

### DIFF
--- a/.tours/welcome-to-dreamhouse.tour
+++ b/.tours/welcome-to-dreamhouse.tour
@@ -35,7 +35,7 @@
     {
       "title": "Property Controller",
       "file": "force-app/main/default/classes/PropertyController.cls",
-      "line": 45,
+      "line": 13,
       "description": "The `getPagedPropertyList` method from the `PropertyController` Apex class is where properties are retrieved from the Platform.\n\nThe method builds a SOQL query with the provided filters and returns a paginated list of `Property__c` records wrapped in a `PagedResult` object.\n\n`getPagedPropertyList` is exposed to Lightning Web Components thanks to the `@AuraEnabled` annotation. The `cacheable=true` attribute indicates that the returned data is cached.\n\n---\n\nWhile there is a lot to get to know in Dreamhouse, and a lot of code, we'd like to leave off the code tour at this point and suggest you explore the app further in a couple of other ways. \n- One way you can do this is to use our [Quick Start](https://trailhead.salesforce.com/en/content/learn/projects/quick-start-dreamhouse-sample-app) on Trailhead. This will walk you through deploying the app and getting to know it a bit, as well as explore some of the other code samples. \n- But if you prefer to take yourself through the app, you can skip right to the installation instructions that are available in the git repo's [README](https://github.com/trailheadapps/dreamhouse-lwc). From there you can explore the examples bit by bit. There is also an in-app tour that will familiarize you with the app. \n- Lastly, if notice any issue with the app, please open an [issue](https://github.com/trailheadapps/dreamhouse-lwc/issues/new/choose) and let us know.\n\nThanks! And enjoy the Dreamhouse sample app. "
     }
   ],

--- a/force-app/main/default/aura/auraPropertyListMap/auraPropertyListMap.cmp
+++ b/force-app/main/default/aura/auraPropertyListMap/auraPropertyListMap.cmp
@@ -31,7 +31,7 @@
         aura:id="propertySelectedMessageChannel"
     />
 
-    <lightning:card>
+    <article class="slds-card">
         <div aura:id="map"></div>
-    </lightning:card>
+    </article>
 </aura:component>

--- a/force-app/main/default/aura/auraPropertyListMap/auraPropertyListMapHelper.js
+++ b/force-app/main/default/aura/auraPropertyListMap/auraPropertyListMapHelper.js
@@ -1,20 +1,22 @@
 ({
     getProperties: function getProperties(component) {
-        var action = component.get('c.getPropertyList');
+        var action = component.get('c.getPagedPropertyList');
 
         action.setParams({
             searchKey: component.get('v.searchKey'),
             maxPrice: component.get('v.maxPrice'),
             minBedrooms: component.get('v.minBedrooms'),
-            minBathrooms: component.get('v.minBathrooms')
+            minBathrooms: component.get('v.minBathrooms'),
+            pageSize: 100,
+            pageNumber: 1
         });
         action.setCallback(this, function (response) {
             var state = response.getState();
 
             if (state === 'SUCCESS') {
-                var properties = response.getReturnValue();
+                var pagedResults = response.getReturnValue();
 
-                component.set('v.properties', properties);
+                component.set('v.properties', pagedResults.records);
             } else {
                 var toastEvent = $A.get('e.force:showToast');
 

--- a/force-app/main/default/classes/PropertyController.cls
+++ b/force-app/main/default/classes/PropertyController.cls
@@ -1,39 +1,14 @@
 public with sharing class PropertyController {
-    @AuraEnabled(cacheable=true)
-    public static Property__c[] getPropertyList(
-        String searchKey,
-        Decimal maxPrice,
-        Integer minBedrooms,
-        Integer minBathrooms
-    ) {
-        String key = '%' + searchKey + '%';
-        return [
-            SELECT
-                Id,
-                address__c,
-                city__c,
-                state__c,
-                description__c,
-                price__c,
-                baths__c,
-                beds__c,
-                thumbnail__c,
-                location__latitude__s,
-                location__longitude__s
-            FROM Property__c
-            WHERE
-                (title__c LIKE :key
-                OR city__c LIKE :key
-                OR tags__c LIKE :key)
-                AND price__c <= :maxPrice
-                AND beds__c >= :minBedrooms
-                AND baths__c >= :minBathrooms
-            WITH SECURITY_ENFORCED
-            ORDER BY price__c
-            LIMIT 100
-        ];
-    }
-
+    /**
+     * Endpoint that retrieves a paged and filtered list of properties
+     * @param searchKey String used for searching on property title, city and tags
+     * @param maxPrice Maximum price
+     * @param minBedrooms Minimum number of bedrooms
+     * @param minBathrooms Minimum number of bathrooms
+     * @param pageSize Number of properties per page
+     * @param pageNumber Page number
+     * @return PagedResult object holding the paged and filtered list of properties
+     */
     @AuraEnabled(cacheable=true)
     public static PagedResult getPagedPropertyList(
         String searchKey,
@@ -76,7 +51,9 @@ public with sharing class PropertyController {
                 price__c,
                 baths__c,
                 beds__c,
-                thumbnail__c
+                thumbnail__c,
+                location__latitude__s,
+                location__longitude__s
             FROM property__c
             WHERE
                 (title__c LIKE :key
@@ -93,6 +70,11 @@ public with sharing class PropertyController {
         return result;
     }
 
+    /**
+     * Endpoint that retrieves pictures associated with a property
+     * @param propertyId Property Id
+     * @return List of ContentVersion holding the pictures
+     */
     @AuraEnabled(cacheable=true)
     public static List<ContentVersion> getPictures(Id propertyId) {
         List<ContentDocumentLink> links = [

--- a/force-app/main/default/classes/PropertyController.cls
+++ b/force-app/main/default/classes/PropertyController.cls
@@ -60,8 +60,8 @@ public with sharing class PropertyController {
                 Baths__c,
                 Beds__c,
                 Thumbnail__c,
-                Location__latitude__s,
-                Location__longitude__s
+                Location__Latitude__s,
+                Location__Longitude__s
             FROM Property__c
             WHERE
                 (Title__c LIKE :searchPattern

--- a/force-app/main/default/classes/PropertyController.cls
+++ b/force-app/main/default/classes/PropertyController.cls
@@ -1,4 +1,7 @@
 public with sharing class PropertyController {
+    private static final Decimal DEFAULT_MAX_PRICE = 9999999;
+    private static final Integer DEFAULT_PAGE_SIZE = 9;
+
     /**
      * Endpoint that retrieves a paged and filtered list of properties
      * @param searchKey String used for searching on property title, city and tags
@@ -18,53 +21,58 @@ public with sharing class PropertyController {
         Integer pageSize,
         Integer pageNumber
     ) {
-        maxPrice = Decimal.valueOf(maxPrice + '');
-        minBedrooms = Integer.valueOf(minBedrooms + '');
-        minBathrooms = Integer.valueOf(minBathrooms + '');
-        pageSize = Integer.valueOf(pageSize + '');
-        pageNumber = Integer.valueOf(pageNumber + '');
+        // Normalize inputs
+        Decimal safeMaxPrice = (maxPrice == null
+            ? DEFAULT_MAX_PRICE
+            : maxPrice);
+        Integer safeMinBedrooms = (minBedrooms == null ? 0 : minBedrooms);
+        Integer safeMinBathrooms = (minBathrooms == null ? 0 : minBathrooms);
+        Integer safePageSize = (pageSize == null
+            ? DEFAULT_PAGE_SIZE
+            : pageSize);
+        Integer safePageNumber = (pageNumber == null ? 1 : pageNumber);
 
-        Integer pSize = (Integer) pageSize;
-        String key = '%' + searchKey + '%';
-        Integer offset = ((Integer) pageNumber - 1) * pSize;
+        String searchPattern = '%' + searchKey + '%';
+        Integer offset = (safePageNumber - 1) * safePageSize;
+
         PagedResult result = new PagedResult();
-        result.pageSize = pSize;
-        result.pageNumber = (Integer) pageNumber;
+        result.pageSize = safePageSize;
+        result.pageNumber = safePageNumber;
         result.totalItemCount = [
             SELECT COUNT()
             FROM Property__c
             WHERE
-                (title__c LIKE :key
-                OR city__c LIKE :key
-                OR tags__c LIKE :key)
-                AND price__c <= :maxPrice
-                AND beds__c >= :minBedrooms
-                AND baths__c >= :minBathrooms
+                (Title__c LIKE :searchPattern
+                OR City__c LIKE :searchPattern
+                OR Tags__c LIKE :searchPattern)
+                AND Price__c <= :safeMaxPrice
+                AND Beds__c >= :safeMinBedrooms
+                AND Baths__c >= :safeMinBathrooms
         ];
         result.records = [
             SELECT
                 Id,
-                address__c,
-                city__c,
-                state__c,
-                description__c,
-                price__c,
-                baths__c,
-                beds__c,
-                thumbnail__c,
-                location__latitude__s,
-                location__longitude__s
-            FROM property__c
+                Address__c,
+                City__c,
+                State__c,
+                Description__c,
+                Price__c,
+                Baths__c,
+                Beds__c,
+                Thumbnail__c,
+                Location__latitude__s,
+                Location__longitude__s
+            FROM Property__c
             WHERE
-                (title__c LIKE :key
-                OR city__c LIKE :key
-                OR tags__c LIKE :key)
-                AND price__c <= :maxPrice
-                AND beds__c >= :minBedrooms
-                AND baths__c >= :minBathrooms
+                (Title__c LIKE :searchPattern
+                OR City__c LIKE :searchPattern
+                OR Tags__c LIKE :searchPattern)
+                AND Price__c <= :safeMaxPrice
+                AND Beds__c >= :safeMinBedrooms
+                AND Baths__c >= :safeMinBathrooms
             WITH SECURITY_ENFORCED
-            ORDER BY price__c
-            LIMIT :pSize
+            ORDER BY Price__c
+            LIMIT :safePageSize
             OFFSET :offset
         ];
         return result;

--- a/force-app/main/default/classes/TestPropertyController.cls
+++ b/force-app/main/default/classes/TestPropertyController.cls
@@ -16,18 +16,6 @@ private class TestPropertyController {
         }
         insert properties;
     }
-    static testMethod void testGetPropertyList() {
-        TestPropertyController.createProperties(5);
-        Test.startTest();
-        Property__c[] properties = PropertyController.getPropertyList(
-            '',
-            999999,
-            0,
-            0
-        );
-        Test.stopTest();
-        System.assertEquals(5, properties.size());
-    }
     static testMethod void testGetPagedPropertyList() {
         TestPropertyController.createProperties(5);
         Test.startTest();


### PR DESCRIPTION
Removed `PropertyController.getPropertyList` Apex method and used `getPagedPropertyList` instead.
This change impacts the code of the `auraPropertyListMap` Aura component visible in the Property finder.