### PR TITLE
Removes unneeded "force" namespace from README auth commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DreamHouse is a sample application that demonstrates the unique value propositio
 1. If you haven't already done so, authorize your hub org and provide it with an alias (**myhuborg** in the command below):
 
     ```
-    sfdx force:auth:web:login -d -a myhuborg
+    sfdx auth:web:login -d -a myhuborg
     ```
 
 1. Clone this repository:
@@ -146,7 +146,7 @@ Make sure to start from a brand-new environment to avoid conflicts with previous
 1. Authorize your Trailhead Playground or Developer org and provide it with an alias (**mydevorg** in the command below):
 
     ```
-    sfdx force:auth:web:login -s -a mydevorg
+    sfdx auth:web:login -s -a mydevorg
     ```
 
 1. Start an In-App Guidance trial


### PR DESCRIPTION
### What does this PR do?
Removes unneeded "force" namespace from README auth commands

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[N/A] Tests for the proposed changes have been added/updated.
[N/A] Code linting and formatting was performed.

### Functionality Before
README used auth commands with the force namespace

### Functionality After
README doesn't use the force namespace on auth commands as it's no longer needed (https://github.com/forcedotcom/cli/blob/main/releasenotes/README.md)