### PR TITLE
Improved test for access rights in testGetPagedPropertyList

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,6 +1,5 @@
 {
     "orgName": "Dreamhouse",
-    "language": "en_US",
     "edition": "Developer",
     "features": ["Walkthroughs", "EnableSetPasswordInApi"],
     "settings": {

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,5 +1,6 @@
 {
     "orgName": "Dreamhouse",
+    "language": "en_US",
     "edition": "Developer",
     "features": ["Walkthroughs", "EnableSetPasswordInApi"],
     "settings": {

--- a/force-app/main/default/classes/TestPropertyController.cls
+++ b/force-app/main/default/classes/TestPropertyController.cls
@@ -18,9 +18,13 @@ private class TestPropertyController {
     }
     static testMethod void testGetPagedPropertyList() {
         final Profile p = [
-            SELECT Id
+            SELECT Name, Id
             FROM Profile
-            WHERE Name = 'Standard User'
+            WHERE
+                UserType = 'Standard'
+                AND PermissionsPrivacyDataAccess = FALSE
+                AND PermissionsSubmitMacrosAllowed = TRUE
+                AND PermissionsMassInlineEdit = TRUE
             LIMIT 1
         ];
         final User u = new User(

--- a/force-app/main/default/classes/TestPropertyController.cls
+++ b/force-app/main/default/classes/TestPropertyController.cls
@@ -17,18 +17,49 @@ private class TestPropertyController {
         insert properties;
     }
     static testMethod void testGetPagedPropertyList() {
-        TestPropertyController.createProperties(5);
-        Test.startTest();
-        PagedResult result = PropertyController.getPagedPropertyList(
-            '',
-            999999,
-            0,
-            0,
-            10,
-            1
+        final Profile p = [
+            SELECT Id
+            FROM Profile
+            WHERE Name = 'Standard User'
+            LIMIT 1
+        ];
+        final User u = new User(
+            Alias = 'standt',
+            Email = 'standarduser@testorg.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'Testing',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = 'standarduser@dreamhouse-testorg.com'
         );
-        Test.stopTest();
-        System.assertEquals(5, result.records.size());
+        insert u;
+        final PermissionSet ps = [
+            SELECT Id
+            FROM PermissionSet
+            WHERE Name = 'dreamhouse'
+        ];
+        insert new PermissionSetAssignment(
+            AssigneeId = u.Id,
+            PermissionSetId = ps.Id
+        );
+
+        TestPropertyController.createProperties(5);
+        PagedResult result;
+        System.runAs(u) {
+            Test.startTest();
+            result = PropertyController.getPagedPropertyList(
+                '',
+                999999,
+                0,
+                0,
+                10,
+                1
+            );
+            Test.stopTest();
+            System.assertEquals(5, result.records.size());
+        }
     }
 
     static testMethod void testGetPicturesNoResults() {


### PR DESCRIPTION
### What does this PR do?
set language in project-scratch-def.json to ensure scratch org is created in English to ensure apex unit test cases pass due top WITH ENFORCE_SECURITY. It also means that force:package:version:create with --codecoverage needs to explicitly reference the scratch org file.

### What issues does this PR fix or reference?
Unable to build package version with codecoverage as org wasn't necessarily created in English and WITH SECURITY_ENFORCED require a user with correct perms

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
