### PR TITLE
Add location / distance to property component

### DIFF
--- a/force-app/main/default/flexipages/Property_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Property_Record_Page.flexipage-meta.xml
@@ -686,6 +686,12 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentName>propertyLocation</componentName>
+                <identifier>c_propertyLocation</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>brokerCard</componentName>
                 <identifier>brokerCard</identifier>
             </componentInstance>

--- a/force-app/main/default/lwc/brokerCard/brokerCard.js-meta.xml
+++ b/force-app/main/default/lwc/brokerCard/brokerCard.js-meta.xml
@@ -17,5 +17,4 @@
             </supportedFormFactors>
         </targetConfig>
     </targetConfigs>
-
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/propertyLocation/__tests__/data/getRecord.json
+++ b/force-app/main/default/lwc/propertyLocation/__tests__/data/getRecord.json
@@ -1,0 +1,20 @@
+{
+    "apiName": "Property__c",
+    "childRelationships": {},
+    "id": "a015I000002taYUQAY",
+    "lastModifiedById": "0055I000001RjtIQAS",
+    "lastModifiedDate": "2020-06-09T07:48:54.000Z",
+    "recordTypeId": "012000000000000AAA",
+    "recordTypeInfo": null,
+    "systemModstamp": "2020-06-09T07:48:54.000Z",
+    "fields": {
+        "Location__Latitude__s": {
+            "displayValue": "37.751",
+            "value": "37.751"
+        },
+        "Location__Longitude__s": {
+            "displayValue": "-97.822",
+            "value": "-97.822"
+        }
+    }
+}

--- a/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
+++ b/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
@@ -22,8 +22,8 @@ const checkDistanceCalculation = (element) => {
     expect(formattedNumberEl).not.toBe(null);
 
     // Compare with coordinates in mobileCapabilities.js mock
-    expect(latitudeEl.textContent).toBe('42.361145');
-    expect(longitudeEl.textContent).toBe('-71.057083');
+    expect(latitudeEl.textContent.trim()).toBe('42.361145');
+    expect(longitudeEl.textContent.trim()).toBe('-71.057083');
     // Distance between mocked property and mocked location
     expect(formattedNumberEl.value).toBe(1444.43371701009);
 };

--- a/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
+++ b/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
@@ -1,0 +1,114 @@
+import { createElement } from 'lwc';
+import PropertyLocation from 'c/propertyLocation';
+import { getRecord } from 'lightning/uiRecordApi';
+import { getLocationService } from 'lightning/mobileCapabilities';
+
+// Realistic property record
+const mockPropertyRecord = require('./data/getRecord.json');
+
+describe('c-property-location', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    // Helper function to wait until the microtask queue is empty.
+    // Used when having to wait for asynchronous DOM updates.
+    async function flushPromises() {
+        return Promise.resolve();
+    }
+
+    it('renders an error panel when no location services are available', async () => {
+        const element = createElement('c-property-location', {
+            is: PropertyLocation
+        });
+
+        document.body.appendChild(element);
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const panelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(panelEl).not.toBeNull();
+    });
+
+    it('renders an error panel when getRecord returns an error', async () => {
+        const element = createElement('c-property-location', {
+            is: PropertyLocation
+        });
+
+        document.body.appendChild(element);
+
+        // Simulate error
+        getRecord.error();
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        const panelEl = element.shadowRoot.querySelector('c-error-panel');
+        expect(panelEl).not.toBeNull();
+    });
+
+    it('renders coordinates and distance when browser location is available', async () => {
+        const element = createElement('c-property-location', {
+            is: PropertyLocation
+        });
+        element.recordId = mockPropertyRecord.id;
+        document.body.appendChild(element);
+
+        // Simulate property selection
+        getRecord.emit(mockPropertyRecord);
+
+        // Simulate browser location
+        // TODO
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        /*const divEl = element.shadowRoot.querySelector('div.location');
+        expect(divEl).not.toBeNull();*/
+    });
+
+    it('renders coordinates and distance when device location is available', async () => {
+        // Simulate device location is available
+        getLocationService().isAvailable.mockReturnValue(true);
+        console.log(getLocationService().isAvailable()); // THIS OVERWRITE IS NOT WORKING!
+
+        const element = createElement('c-property-location', {
+            is: PropertyLocation
+        });
+        element.recordId = mockPropertyRecord.id;
+        document.body.appendChild(element);
+
+        // Simulate property selection
+        getRecord.emit(mockPropertyRecord);
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        /*const divEl = element.shadowRoot.querySelector('div.location');
+        expect(divEl).not.toBeNull();*/
+    });
+
+    it('is accessible when panel is shown', async () => {
+        const element = createElement('c-property-location', {
+            is: PropertyLocation
+        });
+
+        document.body.appendChild(element);
+
+        // Simulate property selection
+        getRecord.emit(mockPropertyRecord);
+
+        // Simulate browser location
+        // TODO
+
+        // Wait for any asynchronous DOM updates
+        await flushPromises();
+
+        await expect(element).toBeAccessible();
+    });
+});

--- a/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
+++ b/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
@@ -77,7 +77,7 @@ describe('c-property-location', () => {
     // eslint-disable-next-line jest/expect-expect
     it('renders coordinates and distance when browser location is available', async () => {
         // Simulate browser location
-        navigator.geolocation = mockGeolocation;
+        global.navigator.geolocation = mockGeolocation;
 
         const element = createElement('c-property-location', {
             is: PropertyLocation
@@ -91,7 +91,7 @@ describe('c-property-location', () => {
         // Wait for any asynchronous DOM updates
         await flushPromises();
 
-        // checkDistanceCalculation(element);
+        checkDistanceCalculation(element);
     });
 
     // eslint-disable-next-line jest/expect-expect

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.html
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.html
@@ -3,16 +3,17 @@
         title="Distance to the Property"
         icon-name="standard:location"
     >
-        <template if:true={distance}>
-            <div class="slds-var-m-around_medium location">
-                <div class="slds-text-heading_small">
-                    Current latitude: <b>{myLocation.latitude}</b>
-                </div>
-                <div class="slds-text-heading_small">
-                    Current longitude: <b>{myLocation.longitude}</b>
-                </div>
-                <!-- prettier-ignore -->
-                <div class="slds-text-heading_small">
+        <template if:false={error}>
+            <template if:true={distance}>
+                <div class="slds-var-m-around_medium location">
+                    <div class="slds-text-heading_small">
+                        Current latitude: <b>{myLocation.latitude}</b>
+                    </div>
+                    <div class="slds-text-heading_small">
+                        Current longitude: <b>{myLocation.longitude}</b>
+                    </div>
+                    <!-- prettier-ignore -->
+                    <div class="slds-text-heading_small">
                     Distance to property: <b>
                         <lightning-formatted-number
                             value={distance}
@@ -20,11 +21,12 @@
                         ></lightning-formatted-number> miles
                     </b>
                 </div>
-            </div>
-        </template>
-        <template if:false={distance}>
-            <lightning-spinner alternative-text="Loading..." size="small">
-            </lightning-spinner>
+                </div>
+            </template>
+            <template if:false={distance}>
+                <lightning-spinner alternative-text="Loading..." size="small">
+                </lightning-spinner>
+            </template>
         </template>
         <template if:true={error}>
             <c-error-panel

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.html
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.html
@@ -4,7 +4,7 @@
         icon-name="standard:location"
     >
         <template if:true={distance}>
-            <div class="slds-var-m-around_medium">
+            <div class="slds-var-m-around_medium location">
                 <div class="slds-text-heading_small">
                     Current latitude: <b>{myLocation.latitude}</b>
                 </div>

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.html
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.html
@@ -7,10 +7,10 @@
             <template if:true={distance}>
                 <div class="slds-var-m-around_medium location">
                     <div class="slds-text-heading_small">
-                        Current latitude: <b>{myLocation.latitude}</b>
+                        Current latitude: <b>{location.latitude}</b>
                     </div>
                     <div class="slds-text-heading_small">
-                        Current longitude: <b>{myLocation.longitude}</b>
+                        Current longitude: <b>{location.longitude}</b>
                     </div>
                     <!-- prettier-ignore -->
                     <div class="slds-text-heading_small">

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.html
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.html
@@ -1,0 +1,36 @@
+<template>
+    <lightning-card
+        title="Distance to the Property"
+        icon-name="standard:location"
+    >
+        <template if:true={distance}>
+            <div class="slds-var-m-around_medium">
+                <div class="slds-text-heading_small">
+                    Current latitude: <b>{myLocation.latitude}</b>
+                </div>
+                <div class="slds-text-heading_small">
+                    Current longitude: <b>{myLocation.longitude}</b>
+                </div>
+                <!-- prettier-ignore -->
+                <div class="slds-text-heading_small">
+                    Distance to property: <b>
+                        <lightning-formatted-number
+                            value={distance}
+                            maximum-fraction-digits="2"
+                        ></lightning-formatted-number> miles
+                    </b>
+                </div>
+            </div>
+        </template>
+        <template if:false={distance}>
+            <lightning-spinner alternative-text="Loading..." size="small">
+            </lightning-spinner>
+        </template>
+        <template if:true={error}>
+            <c-error-panel
+                friendly-message="Error computing location."
+                errors={error}
+            ></c-error-panel>
+        </template>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.html
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.html
@@ -7,10 +7,12 @@
             <template if:true={distance}>
                 <div class="slds-var-m-around_medium location">
                     <div class="slds-text-heading_small">
-                        Current latitude: <b>{location.latitude}</b>
+                        Current latitude:
+                        <b class="latitude">{location.latitude}</b>
                     </div>
                     <div class="slds-text-heading_small">
-                        Current longitude: <b>{location.longitude}</b>
+                        Current longitude:
+                        <b class="longitude">{location.longitude}</b>
                     </div>
                     <!-- prettier-ignore -->
                     <div class="slds-text-heading_small">

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.html
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.html
@@ -8,21 +8,21 @@
                 <div class="slds-var-m-around_medium location">
                     <div class="slds-text-heading_small">
                         Current latitude:
-                        <b class="latitude">{location.latitude}</b>
+                        <b class="latitude">&nbsp;{location.latitude}</b>
                     </div>
                     <div class="slds-text-heading_small">
                         Current longitude:
-                        <b class="longitude">{location.longitude}</b>
+                        <b class="longitude">&nbsp;{location.longitude}</b>
                     </div>
-                    <!-- prettier-ignore -->
                     <div class="slds-text-heading_small">
-                    Distance to property: <b>
-                        <lightning-formatted-number
-                            value={distance}
-                            maximum-fraction-digits="2"
-                        ></lightning-formatted-number> miles
-                    </b>
-                </div>
+                        Distance to property:&nbsp;<b>
+                            <lightning-formatted-number
+                                value={distance}
+                                maximum-fraction-digits="2"
+                            ></lightning-formatted-number>
+                            miles
+                        </b>
+                    </div>
                 </div>
             </template>
             <template if:false={distance}>

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js
@@ -10,8 +10,8 @@ const fields = [LATITUDE_FIELD, LONGITUDE_FIELD];
 
 export default class PropertyLocation extends LightningElement {
     error;
-    myDeviceLocationService;
-    myLocation;
+    deviceLocationService;
+    location;
     @api recordId;
 
     @wire(getRecord, { recordId: '$recordId', fields })
@@ -26,8 +26,8 @@ export default class PropertyLocation extends LightningElement {
     }
 
     async connectedCallback() {
-        this.myDeviceLocationService = getLocationService();
-        if (this.myDeviceLocationService.isAvailable()) {
+        this.deviceLocationService = getLocationService();
+        if (this.deviceLocationService.isAvailable()) {
             // Running on the Salesforce mobile app on a device
             await this.calculateLocationFromMobileDevice();
         } else if (navigator.geolocation) {
@@ -40,8 +40,8 @@ export default class PropertyLocation extends LightningElement {
 
     async calculateLocationFromMobileDevice() {
         try {
-            this.myLocation =
-                await this.myDeviceLocationService.getCurrentPosition();
+            this.location =
+                await this.deviceLocationService.getCurrentPosition();
         } catch (error) {
             this.error = error;
         }
@@ -50,7 +50,7 @@ export default class PropertyLocation extends LightningElement {
     calculateLocationFromBrowser() {
         navigator.geolocation.getCurrentPosition(
             (result) => {
-                this.myLocation = result.coords;
+                this.location = result.coords;
             },
             (error) => {
                 this.error = error;
@@ -59,10 +59,10 @@ export default class PropertyLocation extends LightningElement {
     }
 
     get distance() {
-        if (this.myLocation && this.property) {
-            const latitude1 = this.myLocation.latitude;
+        if (this.location && this.property) {
+            const latitude1 = this.location.latitude;
             const latitude2 = getFieldValue(this.property, LATITUDE_FIELD);
-            const longitude1 = this.myLocation.longitude;
+            const longitude1 = this.location.longitude;
             const longitude2 = getFieldValue(this.property, LONGITUDE_FIELD);
             return this.calculateDistance(
                 latitude1,

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js
@@ -25,36 +25,34 @@ export default class PropertyLocation extends LightningElement {
         }
     }
 
-    connectedCallback() {
+    async connectedCallback() {
         this.myDeviceLocationService = getLocationService();
         if (this.myDeviceLocationService.isAvailable()) {
             // Running on the Salesforce mobile app on a device
-            this.getLocationFromMobileDevice();
+            await this.calculateLocationFromMobileDevice();
         } else if (navigator.geolocation) {
             // Running on a browser
-            this.getLocationFromBrowser();
+            this.calculateLocationFromBrowser();
         } else {
             this.error = 'No location services available';
         }
     }
 
-    getLocationFromMobileDevice() {
-        this.myDeviceLocationService
-            .getCurrentPosition()
-            .then((result) => {
-                this.myLocation = result.coords;
-                this.calculateDistance();
-            })
-            .catch((error) => {
-                this.error = error;
-            });
+    async calculateLocationFromMobileDevice() {
+        try {
+            //this.myLocation =
+            const result =
+                await this.myDeviceLocationService.getCurrentPosition();
+            this.myLocation = result.coords;
+        } catch (error) {
+            this.error = error;
+        }
     }
 
-    getLocationFromBrowser() {
+    calculateLocationFromBrowser() {
         navigator.geolocation.getCurrentPosition(
             (result) => {
                 this.myLocation = result.coords;
-                this.calculateDistance();
             },
             (error) => {
                 this.error = error;

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js
@@ -1,0 +1,97 @@
+import { LightningElement, wire, api } from 'lwc';
+import { getLocationService } from 'lightning/mobileCapabilities';
+import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
+
+// Using hardcoded fields due to LWC bug
+const LATITUDE_FIELD = 'Property__c.Location__Latitude__s';
+const LONGITUDE_FIELD = 'Property__c.Location__Longitude__s';
+
+const fields = [LATITUDE_FIELD, LONGITUDE_FIELD];
+
+export default class PropertyLocation extends LightningElement {
+    error;
+    myDeviceLocationService;
+    myLocation;
+    @api recordId;
+
+    @wire(getRecord, { recordId: '$recordId', fields })
+    wiredProperty({ data, error }) {
+        if (data) {
+            this.property = data;
+            this.error = undefined;
+        } else if (error) {
+            this.error = error;
+            this.property = undefined;
+        }
+    }
+
+    connectedCallback() {
+        this.myDeviceLocationService = getLocationService();
+        if (this.myDeviceLocationService.isAvailable()) {
+            // Running on the Salesforce mobile app on a device
+            this.getLocationFromMobileDevice();
+        } else if (navigator.geolocation) {
+            // Running on a browser
+            this.getLocationFromBrowser();
+        } else {
+            this.error = 'No location services available';
+        }
+    }
+
+    getLocationFromMobileDevice() {
+        this.myDeviceLocationService
+            .getCurrentPosition()
+            .then((result) => {
+                this.myLocation = result.coords;
+                this.calculateDistance();
+            })
+            .catch((error) => {
+                this.error = error;
+            });
+    }
+
+    getLocationFromBrowser() {
+        navigator.geolocation.getCurrentPosition(
+            (result) => {
+                this.myLocation = result.coords;
+                this.calculateDistance();
+            },
+            (error) => {
+                this.error = error;
+            }
+        );
+    }
+
+    get distance() {
+        if (this.myLocation && this.property) {
+            const latitude1 = this.myLocation.latitude;
+            const latitude2 = getFieldValue(this.property, LATITUDE_FIELD);
+            const longitude1 = this.myLocation.longitude;
+            const longitude2 = getFieldValue(this.property, LONGITUDE_FIELD);
+            return this.calculateDistance(
+                latitude1,
+                latitude2,
+                longitude1,
+                longitude2
+            );
+        }
+        return false;
+    }
+
+    calculateDistance(latitude1, latitude2, longitude1, longitude2) {
+        // Haversine formula
+        const deg2rad = (deg) => (deg * Math.PI) / 180.0;
+        const earthRadius = 6371; // Radius of the earth in km
+        const dLat = deg2rad(latitude2 - latitude1); // deg2rad below
+        const dLon = deg2rad(longitude2 - longitude1);
+        const a =
+            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(deg2rad(latitude1)) *
+                Math.cos(deg2rad(latitude2)) *
+                Math.sin(dLon / 2) *
+                Math.sin(dLon / 2);
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        const d = earthRadius * c;
+        return d / 1.609344;
+    }
+}

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js
@@ -11,6 +11,7 @@ const fields = [LATITUDE_FIELD, LONGITUDE_FIELD];
 export default class PropertyLocation extends LightningElement {
     error;
     deviceLocationService;
+    distance;
     location;
     @api recordId;
 
@@ -19,6 +20,7 @@ export default class PropertyLocation extends LightningElement {
         if (data) {
             this.property = data;
             this.error = undefined;
+            this.calculateDistance();
         } else if (error) {
             this.error = error;
             this.property = undefined;
@@ -42,6 +44,7 @@ export default class PropertyLocation extends LightningElement {
         try {
             this.location =
                 await this.deviceLocationService.getCurrentPosition();
+            this.calculateDistance();
         } catch (error) {
             this.error = error;
         }
@@ -51,6 +54,7 @@ export default class PropertyLocation extends LightningElement {
         navigator.geolocation.getCurrentPosition(
             (result) => {
                 this.location = result.coords;
+                this.calculateDistance();
             },
             (error) => {
                 this.error = error;
@@ -58,36 +62,27 @@ export default class PropertyLocation extends LightningElement {
         );
     }
 
-    get distance() {
+    calculateDistance() {
         if (this.location && this.property) {
             const latitude1 = this.location.latitude;
             const latitude2 = getFieldValue(this.property, LATITUDE_FIELD);
             const longitude1 = this.location.longitude;
             const longitude2 = getFieldValue(this.property, LONGITUDE_FIELD);
-            return this.calculateDistance(
-                latitude1,
-                latitude2,
-                longitude1,
-                longitude2
-            );
-        }
-        return false;
-    }
 
-    calculateDistance(latitude1, latitude2, longitude1, longitude2) {
-        // Haversine formula
-        const deg2rad = (deg) => (deg * Math.PI) / 180.0;
-        const earthRadius = 6371; // Radius of the earth in km
-        const dLat = deg2rad(latitude2 - latitude1); // deg2rad below
-        const dLon = deg2rad(longitude2 - longitude1);
-        const a =
-            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-            Math.cos(deg2rad(latitude1)) *
-                Math.cos(deg2rad(latitude2)) *
-                Math.sin(dLon / 2) *
-                Math.sin(dLon / 2);
-        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        const d = earthRadius * c;
-        return d / 1.609344;
+            // Haversine formula
+            const deg2rad = (deg) => (deg * Math.PI) / 180.0;
+            const earthRadius = 6371; // Radius of the earth in km
+            const dLat = deg2rad(latitude2 - latitude1); // deg2rad below
+            const dLon = deg2rad(longitude2 - longitude1);
+            const a =
+                Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(deg2rad(latitude1)) *
+                    Math.cos(deg2rad(latitude2)) *
+                    Math.sin(dLon / 2) *
+                    Math.sin(dLon / 2);
+            const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+            const d = earthRadius * c;
+            this.distance = d / 1.609344;
+        }
     }
 }

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js
@@ -34,16 +34,14 @@ export default class PropertyLocation extends LightningElement {
             // Running on a browser
             this.calculateLocationFromBrowser();
         } else {
-            this.error = 'No location services available';
+            this.error = { message: 'No location services available' };
         }
     }
 
     async calculateLocationFromMobileDevice() {
         try {
-            //this.myLocation =
-            const result =
+            this.myLocation =
                 await this.myDeviceLocationService.getCurrentPosition();
-            this.myLocation = result.coords;
         } catch (error) {
             this.error = error;
         }

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js-meta.xml
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js-meta.xml
@@ -4,13 +4,17 @@
     <isExposed>true</isExposed>
     <masterLabel>Property Location</masterLabel>
     <targets>
-        <target>lightning__RecordPage</target>
+    	<target>lightning__RecordPage</target>
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
             <objects>
                 <object>Property__c</object>
             </objects>
+            <supportedFormFactors>
+                <supportedFormFactor type="Large" />
+                <supportedFormFactor type="Small" />
+            </supportedFormFactors>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/propertyLocation/propertyLocation.js-meta.xml
+++ b/force-app/main/default/lwc/propertyLocation/propertyLocation.js-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Property Location</masterLabel>
+    <targets>
+        <target>lightning__RecordPage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>Property__c</object>
+            </objects>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/test/jest-mocks/global/navigator.js
+++ b/force-app/test/jest-mocks/global/navigator.js
@@ -1,5 +1,5 @@
 // Mock browser geolocation service this way:
-// import { mockGeolocation } from "test/jest-mocks/global/navigator"
+// import { mockGeolocation } from '../../../../../test/jest-mocks/global/navigator';
 // navigator.geolocation = mockGeolocation;
 export const mockGeolocation = {
     getCurrentPosition: jest.fn().mockImplementation((success) =>

--- a/force-app/test/jest-mocks/global/navigator.js
+++ b/force-app/test/jest-mocks/global/navigator.js
@@ -1,0 +1,15 @@
+// Mock browser geolocation service this way:
+// import { mockGeolocation } from "test/jest-mocks/global/navigator"
+// navigator.geolocation = mockGeolocation;
+export const mockGeolocation = {
+    getCurrentPosition: jest.fn().mockImplementation((success) =>
+        Promise.resolve(
+            success({
+                coords: {
+                    latitude: 42.361145,
+                    longitude: -71.057083
+                }
+            })
+        )
+    )
+};

--- a/force-app/test/jest-mocks/lightning/mobileCapabilities.js
+++ b/force-app/test/jest-mocks/lightning/mobileCapabilities.js
@@ -1,6 +1,6 @@
 // To activate this mocked device location, add to your test:
 //
-// import { setAvailable } from 'lightning/mobileCapabilities';
+// import { setDeviceLocationServiceAvailable } from 'lightning/mobileCapabilities';
 // setDeviceLocationServiceAvailable(true);
 var _available = false;
 

--- a/force-app/test/jest-mocks/lightning/mobileCapabilities.js
+++ b/force-app/test/jest-mocks/lightning/mobileCapabilities.js
@@ -1,16 +1,21 @@
 // To activate this mocked device location, add to your test:
 //
-// getLocationService().isAvailable.mockReturnValue(true);
+// import { setAvailable } from 'lightning/mobileCapabilities';
+// setDeviceLocationServiceAvailable(true);
+var _available = false;
+
 export const getLocationService = jest.fn().mockImplementation(() => {
     return {
-        isAvailable: jest.fn().mockReturnValue(false),
+        isAvailable: jest.fn().mockReturnValue(_available),
         getCurrentPosition: jest.fn().mockImplementation(() =>
             Promise.resolve({
-                coords: {
-                    latitude: 42.361145,
-                    longitude: -71.057083
-                }
+                latitude: 42.361145,
+                longitude: -71.057083
             })
         )
     };
 });
+
+export const setDeviceLocationServiceAvailable = (value) => {
+    _available = value;
+};

--- a/force-app/test/jest-mocks/lightning/mobileCapabilities.js
+++ b/force-app/test/jest-mocks/lightning/mobileCapabilities.js
@@ -1,0 +1,16 @@
+// To activate this mocked device location, add to your test:
+//
+// getLocationService().isAvailable.mockReturnValue(true);
+export const getLocationService = jest.fn().mockImplementation(() => {
+    return {
+        isAvailable: jest.fn().mockReturnValue(false),
+        getCurrentPosition: jest.fn().mockImplementation(() =>
+            Promise.resolve({
+                coords: {
+                    latitude: 42.361145,
+                    longitude: -71.057083
+                }
+            })
+        )
+    };
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,9 @@ module.exports = {
         '^lightning/platformShowToastEvent$':
             '<rootDir>/force-app/test/jest-mocks/lightning/platformShowToastEvent',
         '^lightning/messageService$':
-            '<rootDir>/force-app/test/jest-mocks/lightning/messageService'
+            '<rootDir>/force-app/test/jest-mocks/lightning/messageService',
+        '^lightning/mobileCapabilities$':
+            '<rootDir>/force-app/test/jest-mocks/lightning/mobileCapabilities'
     },
     setupFilesAfterEnv
 };


### PR DESCRIPTION
### What does this PR do?
Adds a component that shows the current location, got from the browser or [the device](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_lightning_locationservice), and shows your distance to the property 

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After
![Screenshot 2022-05-25 at 11 01 14](https://user-images.githubusercontent.com/12017842/170224766-0b4bca97-c4d6-4757-9001-983e8a865d4b.png)

