### PR TITLE
Add `sf deploy` options file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ $RECYCLE.BIN/
 # VS Code project settings
 .vscode/*
 !.vscode/extensions.json
+
+# sf CLI deploy options
+deploy-options.json


### PR DESCRIPTION
### What does this PR do?

Adds the sf CLI deploy options file to .gitignore

Context:

The `sf deploy` commands allows the user to save the deploy options in a `deploy-options.json` file.
If you choose to save it, it writes it at the root of the sfdx project but the file shouldn't be commited to the project as it contains the org username, test level, etc:

```json
{
  "Salesforce Apps": {
    "testLevel": "NoTestRun",
    "username": "test-hehehehe@example.com",
    "apps": [
      "force-app"
    ]
  }
}
```

### What issues does this PR fix or reference?

N/A

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

After running `sf deploy` and saving the deploy opts, git complains about the untracked file.

### Functionality After

I can save my deploy opts locally, git ignores it.

