### PR TITLE
Bring back property status and align sample data sets

### DIFF
--- a/data/brokers-data.json
+++ b/data/brokers-data.json
@@ -5,7 +5,7 @@
                 "type": "Broker__c",
                 "referenceId": "CarolineBrookerRef"
             },
-            "name": "Caroline Kingsley",
+            "Name": "Caroline Kingsley",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -17,7 +17,7 @@
                 "type": "Broker__c",
                 "referenceId": "MichaelJonesRef"
             },
-            "name": "Michael Jones",
+            "Name": "Michael Jones",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -29,7 +29,7 @@
                 "type": "Broker__c",
                 "referenceId": "JonathanBradleyRef"
             },
-            "name": "Jonathan Bradley",
+            "Name": "Jonathan Bradley",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -41,7 +41,7 @@
                 "type": "Broker__c",
                 "referenceId": "JenniferWuRef"
             },
-            "name": "Jennifer Wu",
+            "Name": "Jennifer Wu",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -53,7 +53,7 @@
                 "type": "Broker__c",
                 "referenceId": "OliviaGreenRef"
             },
-            "name": "Olivia Green",
+            "Name": "Olivia Green",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -65,7 +65,7 @@
                 "type": "Broker__c",
                 "referenceId": "MiriamAupontRef"
             },
-            "name": "Miriam Aupont",
+            "Name": "Miriam Aupont",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -77,7 +77,7 @@
                 "type": "Broker__c",
                 "referenceId": "MichelleLambertRef"
             },
-            "name": "Michelle Lambert",
+            "Name": "Michelle Lambert",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",
@@ -89,7 +89,7 @@
                 "type": "Broker__c",
                 "referenceId": "VictorOchoaRef"
             },
-            "name": "Victor Ochoa",
+            "Name": "Victor Ochoa",
             "Title__c": "Senior Broker",
             "Phone__c": "617-244-3672",
             "Mobile_Phone__c": "617-244-3672",

--- a/data/properties-data.json
+++ b/data/properties-data.json
@@ -19,7 +19,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house01sq.jpg",
             "Tags__c": "victorian",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@CarolineBrookerRef"
+            "Broker__c": "@CarolineBrookerRef",
+            "Status__c": "Available"
         },
         {
             "attributes": {
@@ -40,7 +41,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house02sq.jpg",
             "Tags__c": "colonial",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@MichaelJonesRef"
+            "Broker__c": "@MichaelJonesRef",
+            "Status__c": "Contracted"
         },
         {
             "attributes": {
@@ -48,7 +50,7 @@
                 "referenceId": "72FrancisStRef"
             },
             "Name": "Modern City Living",
-            "Address__c": "72 Francis st",
+            "Address__c": "72 Francis St",
             "City__c": "Boston",
             "State__c": "MA",
             "Zip__c": "02420",
@@ -61,7 +63,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house03sq.jpg",
             "Tags__c": "contemporary",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@JonathanBradleyRef"
+            "Broker__c": "@JonathanBradleyRef",
+            "Status__c": "Pre Market"
         },
         {
             "attributes": {
@@ -69,7 +72,7 @@
                 "referenceId": "32PrinceStRef"
             },
             "Name": "Stunning Colonial",
-            "Address__c": "32 Prince st",
+            "Address__c": "32 Prince St",
             "City__c": "Cambridge",
             "State__c": "MA",
             "Zip__c": "02420",
@@ -82,7 +85,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house04sq.jpg",
             "Tags__c": "colonial",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@JenniferWuRef"
+            "Broker__c": "@JenniferWuRef",
+            "Status__c": "Available"
         },
         {
             "attributes": {
@@ -103,7 +107,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house05sq.jpg",
             "Tags__c": "contemporary",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@OliviaGreenRef"
+            "Broker__c": "@OliviaGreenRef",
+            "Status__c": "Closed"
         },
         {
             "attributes": {
@@ -124,7 +129,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house06sq.jpg",
             "Tags__c": "colonial",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@MiriamAupontRef"
+            "Broker__c": "@MiriamAupontRef",
+            "Status__c": "Contracted"
         },
         {
             "attributes": {
@@ -145,7 +151,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house07sq.jpg",
             "Tags__c": "colonial",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@MichelleLambertRef"
+            "Broker__c": "@MichelleLambertRef",
+            "Status__c": "Available"
         },
         {
             "attributes": {
@@ -153,7 +160,7 @@
                 "referenceId": "48BrattleStRef"
             },
             "Name": "Heart of Harvard Square",
-            "Address__c": "48 Brattle st",
+            "Address__c": "48 Brattle St",
             "City__c": "Cambridge",
             "State__c": "MA",
             "Zip__c": "02420",
@@ -166,7 +173,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house10sq.jpg",
             "Tags__c": "victorian",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@VictorOchoaRef"
+            "Broker__c": "@VictorOchoaRef",
+            "Status__c": "Under Agreement"
         },
         {
             "attributes": {
@@ -187,7 +195,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house09sq.jpg",
             "Tags__c": "contemporary",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@CarolineBrookerRef"
+            "Broker__c": "@CarolineBrookerRef",
+            "Status__c": "Available"
         },
         {
             "attributes": {
@@ -208,7 +217,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house08sq.jpg",
             "Tags__c": "contemporary",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@MichaelJonesRef"
+            "Broker__c": "@MichaelJonesRef",
+            "Status__c": "Available"
         },
         {
             "attributes": {
@@ -229,7 +239,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house11sq.jpg",
             "Tags__c": "contemporary",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@JonathanBradleyRef"
+            "Broker__c": "@JonathanBradleyRef",
+            "Status__c": "Available"
         },
         {
             "attributes": {
@@ -250,7 +261,8 @@
             "Thumbnail__c": "https://s3-us-west-1.amazonaws.com/sfdc-demo/realty/house12sq.jpg",
             "Tags__c": "contemporary",
             "Description__c": "Lorem ipsum dolor sit amet",
-            "Broker__c": "@JenniferWuRef"
+            "Broker__c": "@JenniferWuRef",
+            "Status__c": "Available"
         }
     ]
 }

--- a/force-app/main/default/globalValueSets/Property_Status.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/Property_Status.globalValueSet-meta.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Contracted</fullName>
+        <default>false</default>
+        <label>Contracted</label>
+    </customValue>
+    <customValue>
+        <fullName>Pre Market</fullName>
+        <default>false</default>
+        <label>Pre Market</label>
+    </customValue>
+    <customValue>
+        <fullName>Available</fullName>
+        <default>false</default>
+        <label>Available</label>
+    </customValue>
+    <customValue>
+        <fullName>Under Agreement</fullName>
+        <default>false</default>
+        <label>Under Agreement</label>
+    </customValue>
+    <customValue>
+        <fullName>Closed</fullName>
+        <default>false</default>
+        <label>Closed</label>
+    </customValue>
+    <masterLabel>Property Status</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/objects/Property__c/fields/Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Property__c/fields/Status__c.field-meta.xml
@@ -9,33 +9,7 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <valueSetDefinition>
-            <sorted>false</sorted>
-            <value>
-                <fullName>Contracted</fullName>
-                <default>false</default>
-                <label>Contracted</label>
-            </value>
-            <value>
-                <fullName>Pre Market</fullName>
-                <default>false</default>
-                <label>Pre Market</label>
-            </value>
-            <value>
-                <fullName>Available</fullName>
-                <default>false</default>
-                <label>Available</label>
-            </value>
-            <value>
-                <fullName>Under Agreement</fullName>
-                <default>false</default>
-                <label>Under Agreement</label>
-            </value>
-            <value>
-                <fullName>Closed</fullName>
-                <default>false</default>
-                <label>Closed</label>
-            </value>
-        </valueSetDefinition>
+        <restricted>true</restricted>
+        <valueSetName>Property_Status</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/Property__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/Property__c/listViews/All.listView-meta.xml
@@ -5,6 +5,7 @@
     <columns>City__c</columns>
     <columns>Beds__c</columns>
     <columns>Price__c</columns>
+    <columns>Status__c</columns>
     <filterScope>Everything</filterScope>
     <label>All</label>
 </ListView>

--- a/force-app/main/default/staticresources/sample_data_properties.json
+++ b/force-app/main/default/staticresources/sample_data_properties.json
@@ -1,7 +1,7 @@
 [
     {
         "Name": "Stunning Victorian",
-        "Address__c": "18 Henry st",
+        "Address__c": "18 Henry St",
         "City__c": "Cambridge",
         "State__c": "MA",
         "Zip__c": "01742",
@@ -16,11 +16,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 1
-        }
+        },
+        "Status__c": "Available"
     },
     {
         "Name": "Ultimate Sophistication",
-        "Address__c": "24 Pearl st",
+        "Address__c": "24 Pearl St",
         "City__c": "Cambridge",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -35,11 +36,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 2
-        }
+        },
+        "Status__c": "Contracted"
     },
     {
         "Name": "Modern City Living",
-        "Address__c": "72 Francis st",
+        "Address__c": "72 Francis St",
         "City__c": "Boston",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -54,11 +56,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 3
-        }
+        },
+        "Status__c": "Pre Market"
     },
     {
         "Name": "Stunning Colonial",
-        "Address__c": "32 Prince st",
+        "Address__c": "32 Prince St",
         "City__c": "Cambridge",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -73,10 +76,11 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 4
-        }
+        },
+        "Status__c": "Available"
     },
     {
-        "Name": "Waterfront in the city",
+        "Name": "Waterfront in the City",
         "Address__c": "110 Baxter Street",
         "City__c": "Boston",
         "State__c": "MA",
@@ -92,11 +96,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 5
-        }
+        },
+        "Status__c": "Closed"
     },
     {
         "Name": "Quiet Retreat",
-        "Address__c": "448 Hanover st",
+        "Address__c": "448 Hanover St",
         "City__c": "Boston",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -111,7 +116,8 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 6
-        }
+        },
+        "Status__c": "Contracted"
     },
     {
         "Name": "City Living",
@@ -130,11 +136,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 7
-        }
+        },
+        "Status__c": "Available"
     },
     {
         "Name": "Heart of Harvard Square",
-        "Address__c": "48 Brattle st",
+        "Address__c": "48 Brattle St",
         "City__c": "Cambridge",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -149,7 +156,8 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 8
-        }
+        },
+        "Status__c": "Under Agreement"
     },
     {
         "Name": "Seaport District Retreat",
@@ -168,7 +176,8 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 1
-        }
+        },
+        "Status__c": "Available"
     },
     {
         "Name": "Contemporary City Living",
@@ -187,11 +196,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 2
-        }
+        },
+        "Status__c": "Available"
     },
     {
         "Name": "Architectural Details",
-        "Address__c": "95 Gloucester st",
+        "Address__c": "95 Gloucester St",
         "City__c": "Boston",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -206,11 +216,12 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 3
-        }
+        },
+        "Status__c": "Available"
     },
     {
         "Name": "Contemporary Luxury",
-        "Address__c": "145 Commonwealth ave",
+        "Address__c": "145 Commonwealth Ave",
         "City__c": "Boston",
         "State__c": "MA",
         "Zip__c": "02420",
@@ -225,6 +236,7 @@
         "Description__c": "Lorem ipsum dolor sit amet",
         "Broker__r": {
             "Broker_Id__c": 4
-        }
+        },
+        "Status__c": "Available"
     }
 ]


### PR DESCRIPTION
feat: moved property status to global picklist
fix: re-aligned sample data sets and added statuses