### PR TITLE
feat: updates to support using Code Analyzer in place of ESLint extension in Salesforce Extension Pack + fix import in LWC test files to remove error

### DIFF
--- a/code-analyzer.yml
+++ b/code-analyzer.yml
@@ -1,0 +1,3 @@
+engines:
+    eslint:
+        auto_discover_eslint_config: true

--- a/code-analyzer.yml
+++ b/code-analyzer.yml
@@ -1,3 +1,4 @@
 engines:
     eslint:
         auto_discover_eslint_config: true
+        disable_lwc_base_config: true

--- a/force-app/main/default/lwc/.eslintrc.json
+++ b/force-app/main/default/lwc/.eslintrc.json
@@ -1,13 +1,14 @@
 {
-    "extends": ["@salesforce/eslint-config-lwc/recommended"],
     "overrides": [
         {
             "files": ["*.test.js"],
+            "plugins": ["jest"],
             "rules": {
                 "@lwc/lwc/no-unexpected-wire-adapter-usages": "off"
             },
             "env": {
-                "node": true
+                "node": true,
+                "jest/globals": true
             }
         }
     ]

--- a/force-app/main/default/lwc/.eslintrc.json
+++ b/force-app/main/default/lwc/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "extends": ["@salesforce/eslint-config-lwc/recommended"],
     "overrides": [
         {
             "files": ["*.test.js"],

--- a/force-app/main/default/lwc/barcodeScanner/__tests__/barcodeScanner.test.js
+++ b/force-app/main/default/lwc/barcodeScanner/__tests__/barcodeScanner.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import { getNavigateCalledWith } from 'lightning/navigation';
 import BarcodeScanner from 'c/barcodeScanner';
 

--- a/force-app/main/default/lwc/brokerCard/__tests__/brokerCard.test.js
+++ b/force-app/main/default/lwc/brokerCard/__tests__/brokerCard.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import BrokerCard from 'c/brokerCard';
 import { getNavigateCalledWith } from 'lightning/navigation';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';

--- a/force-app/main/default/lwc/daysOnMarket/__tests__/daysOnMarket.test.js
+++ b/force-app/main/default/lwc/daysOnMarket/__tests__/daysOnMarket.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import DaysOnMarket from 'c/daysOnMarket';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
 import {

--- a/force-app/main/default/lwc/errorPanel/__tests__/errorPanel.test.js
+++ b/force-app/main/default/lwc/errorPanel/__tests__/errorPanel.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ErrorPanel from 'c/errorPanel';
 
 describe('c-error-panel', () => {

--- a/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
+++ b/force-app/main/default/lwc/navigateToRecord/__tests__/navigateToRecord.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import NavigateToRecord from 'c/navigateToRecord';
 import { getNavigateCalledWith } from 'lightning/navigation';
 

--- a/force-app/main/default/lwc/paginator/__tests__/paginator.test.js
+++ b/force-app/main/default/lwc/paginator/__tests__/paginator.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import Paginator from 'c/paginator';
 
 describe('c-paginator', () => {

--- a/force-app/main/default/lwc/propertyCarousel/__tests__/propertyCarousel.test.js
+++ b/force-app/main/default/lwc/propertyCarousel/__tests__/propertyCarousel.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyCarousel from 'c/propertyCarousel';
 import { getRecord } from 'lightning/uiRecordApi';
 import { processImage } from 'lightning/mediaUtils';

--- a/force-app/main/default/lwc/propertyFilter/__tests__/propertyFilter.test.js
+++ b/force-app/main/default/lwc/propertyFilter/__tests__/propertyFilter.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyFilter from 'c/propertyFilter';
 import { publish } from 'lightning/messageService';
 import FILTERSCHANGEMC from '@salesforce/messageChannel/FiltersChange__c';

--- a/force-app/main/default/lwc/propertyListMap/__tests__/propertyListMap.test.js
+++ b/force-app/main/default/lwc/propertyListMap/__tests__/propertyListMap.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyListMap from 'c/propertyListMap';
 import getPagedPropertyList from '@salesforce/apex/PropertyController.getPagedPropertyList';
 

--- a/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
+++ b/force-app/main/default/lwc/propertyLocation/__tests__/propertyLocation.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyLocation from 'c/propertyLocation';
 import { getRecord } from 'lightning/uiRecordApi';
 import { setDeviceLocationServiceAvailable } from 'lightning/mobileCapabilities';

--- a/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
+++ b/force-app/main/default/lwc/propertyMap/__tests__/propertyMap.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyMap from 'c/propertyMap';
 import { getRecord } from 'lightning/uiRecordApi';
 

--- a/force-app/main/default/lwc/propertySummary/__tests__/propertySummary.test.js
+++ b/force-app/main/default/lwc/propertySummary/__tests__/propertySummary.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertySummary from 'c/propertySummary';
 import { getRecord } from 'lightning/uiRecordApi';
 

--- a/force-app/main/default/lwc/propertyTile/__tests__/propertyTile.small.test.js
+++ b/force-app/main/default/lwc/propertyTile/__tests__/propertyTile.small.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyTile from 'c/propertyTile';
 import { getNavigateCalledWith } from 'lightning/navigation';
 

--- a/force-app/main/default/lwc/propertyTile/__tests__/propertyTile.test.js
+++ b/force-app/main/default/lwc/propertyTile/__tests__/propertyTile.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyTile from 'c/propertyTile';
 
 const PROPERTY = {

--- a/force-app/main/default/lwc/propertyTileList/__tests__/propertyTileList.test.js
+++ b/force-app/main/default/lwc/propertyTileList/__tests__/propertyTileList.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import PropertyTileList from 'c/propertyTileList';
 import getPagedPropertyList from '@salesforce/apex/PropertyController.getPagedPropertyList';
 import { publish, subscribe, MessageContext } from 'lightning/messageService';

--- a/force-app/main/default/lwc/sampleDataImporter/__tests__/sampleDataImporter.test.js
+++ b/force-app/main/default/lwc/sampleDataImporter/__tests__/sampleDataImporter.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import SampleDataImporter from 'c/sampleDataImporter';
 import { ShowToastEventName } from 'lightning/platformShowToastEvent';
 import importSampleData from '@salesforce/apex/SampleDataController.importSampleData';


### PR DESCRIPTION
### What does this PR do?
1. Updates the dreamhouse-lwc sample project to make Code Analyzer v5 extension work as expected.
2. Updates the import in LWC test files to remove an error.

### What issues does this PR fix or reference?
@W-18002850@

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before
1. Cannot run Code Analyzer v5 extension on the dreamhouse-lwc sample project without false **no-undef** warnings.
3. Error on the line `import { createElement } from 'lwc'` in all LWC test files.

### Functionality After
1. Code Analyzer v5 extension does the correct linting on the dreamhouse-lwc sample project during a scan.
2. No more errors in LWC test files after the change to `import { createElement } from '@lwc/engine-dom';`.
