### PR TITLE
Added class-level JSDoc comment to PropertyController

### DIFF
--- a/force-app/main/default/classes/PropertyController.cls
+++ b/force-app/main/default/classes/PropertyController.cls
@@ -1,3 +1,8 @@
+/**
+ * Controller class for Property Explorer LWC
+ * Handles property search, filtering, pagination and image retrieval
+ */
+
 public with sharing class PropertyController {
     private static final Decimal DEFAULT_MAX_PRICE = 9999999;
     private static final Integer DEFAULT_PAGE_SIZE = 9;


### PR DESCRIPTION

Added class-level JSDoc comment to PropertyController

## What I changed
Added a class-level JSDoc comment to PropertyController.cls 
to improve code documentation and readability.

## Why
The class was missing a top-level description explaining 
its purpose. This helps other developers understand the 
class at a glance.