### PR TITLE
feat(tour-request): Property Tour Request & Approval — data model + approval routing [T-01, T-02]

### DIFF
--- a/force-app/main/default/approvalProcesses/Tour_Request__c.Tour_Request_Approval.approvalProcess-meta.xml
+++ b/force-app/main/default/approvalProcesses/Tour_Request__c.Tour_Request_Approval.approvalProcess-meta.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApprovalProcess xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>false</active>
+    <allowRecall>true</allowRecall>
+    <allowedSubmitters>
+        <type>owner</type>
+    </allowedSubmitters>
+    <approvalStep>
+        <allowDelegate>false</allowDelegate>
+        <assignedApprover>
+            <approver>
+                <type>relatedUserField</type>
+                <name>Realtor_User__c</name>
+            </approver>
+            <whenMultipleApprovers>FirstResponse</whenMultipleApprovers>
+        </assignedApprover>
+        <label>Realtor Approval</label>
+        <name>Realtor_Approval</name>
+    </approvalStep>
+    <description
+    >Routes a submitted tour request to the property's realtor for approval. On approval the request is marked Approved and the customer is emailed; on rejection it is marked Rejected and unlocked. Ships inactive — activated in T-03.</description>
+    <emailTemplate>unfiled$public/Tour_Request_Approved</emailTemplate>
+    <enableMobileDeviceAccess>false</enableMobileDeviceAccess>
+    <entryCriteria>
+        <criteriaItems>
+            <field>Tour_Request__c.Status__c</field>
+            <operation>equals</operation>
+            <value>Draft</value>
+        </criteriaItems>
+        <criteriaItems>
+            <field>Tour_Request__c.Realtor_User__c</field>
+            <operation>notEqual</operation>
+        </criteriaItems>
+    </entryCriteria>
+    <finalApprovalActions>
+        <action>
+            <name>Set_Status_Approved</name>
+            <type>FieldUpdate</type>
+        </action>
+        <action>
+            <name>Tour_Request_Approved_Customer</name>
+            <type>Alert</type>
+        </action>
+    </finalApprovalActions>
+    <finalApprovalRecordLock>false</finalApprovalRecordLock>
+    <finalRejectionActions>
+        <action>
+            <name>Set_Status_Rejected</name>
+            <type>FieldUpdate</type>
+        </action>
+    </finalRejectionActions>
+    <finalRejectionRecordLock>false</finalRejectionRecordLock>
+    <initialSubmissionActions>
+        <action>
+            <name>Set_Status_Pending_Approval</name>
+            <type>FieldUpdate</type>
+        </action>
+    </initialSubmissionActions>
+    <label>Tour Request Approval</label>
+    <processOrder>1</processOrder>
+    <recordEditability>AdminOnly</recordEditability>
+    <showApprovalHistory>true</showApprovalHistory>
+</ApprovalProcess>

--- a/force-app/main/default/classes/SampleDataController.cls
+++ b/force-app/main/default/classes/SampleDataController.cls
@@ -22,6 +22,12 @@ public with sharing class SampleDataController {
             brokersJSON,
             List<Broker__c>.class
         );
+        // Stamp the installing user as the realtor so tour-request approvals
+        // route to a real user out-of-box (User Ids can't be seeded from JSON).
+        Id currentUserId = UserInfo.getUserId();
+        for (Broker__c broker : brokers) {
+            broker.Realtor_User__c = currentUserId;
+        }
         insert brokers;
     }
 

--- a/force-app/main/default/classes/TestSampleDataController.cls
+++ b/force-app/main/default/classes/TestSampleDataController.cls
@@ -13,5 +13,14 @@ private class TestSampleDataController {
         Assert.isTrue(propertyNumber > 0, 'Expected properties were created.');
         Assert.isTrue(brokerNumber > 0, 'Expected brokers were created.');
         Assert.isTrue(contactNumber > 0, 'Expected contacts were created.');
+
+        List<Broker__c> brokers = [SELECT Realtor_User__c FROM Broker__c];
+        for (Broker__c broker : brokers) {
+            Assert.areEqual(
+                UserInfo.getUserId(),
+                broker.Realtor_User__c,
+                'Expected each broker to be stamped with the current user as realtor.'
+            );
+        }
     }
 }

--- a/force-app/main/default/classes/TestTourRequestApproval.cls
+++ b/force-app/main/default/classes/TestTourRequestApproval.cls
@@ -1,0 +1,240 @@
+@isTest
+private class TestTourRequestApproval {
+    // --- Fixtures -----------------------------------------------------------
+
+    private static Broker__c makeBroker(Id realtorUserId) {
+        Broker__c broker = new Broker__c(
+            Name = 'Test Broker',
+            Email__c = 'broker@example.com',
+            Phone__c = '1234567890',
+            Mobile_Phone__c = '1234567890',
+            Title__c = 'Broker',
+            Realtor_User__c = realtorUserId
+        );
+        insert broker;
+        return broker;
+    }
+
+    private static Property__c makeProperty(Id brokerId) {
+        Property__c property = new Property__c(
+            Name = 'Test Property',
+            Broker__c = brokerId
+        );
+        insert property;
+        return property;
+    }
+
+    private static Tour_Request__c makeRequest(Id propertyId, Id customerId) {
+        return new Tour_Request__c(
+            Property__c = propertyId,
+            Customer__c = customerId,
+            Requested_Date_Time__c = System.now().addDays(3)
+        );
+    }
+
+    private static Boolean approvalProcessIsActive() {
+        return ![
+                SELECT Id
+                FROM ProcessDefinition
+                WHERE TableEnumOrId = 'Tour_Request__c' AND State = 'Active'
+            ]
+            .isEmpty();
+    }
+
+    // --- Validation rules (deterministic; active regardless of approval) ----
+
+    @isTest
+    static void customerRequiredBlocksInsertWithoutCustomer() {
+        Id me = UserInfo.getUserId();
+        Property__c property = makeProperty(makeBroker(me).Id);
+
+        Tour_Request__c request = makeRequest(property.Id, null);
+        DmlException caught;
+        Test.startTest();
+        try {
+            insert request;
+        } catch (DmlException e) {
+            caught = e;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull(
+            caught,
+            'A tour request without a Customer should be blocked by Customer_Required.'
+        );
+    }
+
+    @isTest
+    static void submitRequiresRealtorBlocksPendingWithoutRealtor() {
+        Id me = UserInfo.getUserId();
+        // Broker has no realtor -> before-save flow leaves Realtor_User__c blank.
+        Property__c property = makeProperty(makeBroker(null).Id);
+        Tour_Request__c request = makeRequest(property.Id, me);
+        insert request;
+
+        request.Status__c = 'Pending Approval';
+        DmlException caught;
+        Test.startTest();
+        try {
+            update request;
+        } catch (DmlException e) {
+            caught = e;
+        }
+        Test.stopTest();
+
+        Assert.isNotNull(
+            caught,
+            'Moving a request to Pending Approval without a realtor should be blocked by Submit_Requires_Realtor.'
+        );
+    }
+
+    // --- Approval lifecycle -------------------------------------------------
+    // Approval.process() requires an ACTIVE approval process. T-02 deploys the
+    // process INACTIVE (activation is T-03). This test therefore asserts the
+    // full submit -> Pending Approval -> approve -> Approved lifecycle when the
+    // process is active, and otherwise asserts the deployed-inactive
+    // precondition. It needs no code change once T-03 activates the process.
+
+    @isTest
+    static void submitAndApproveDrivesStatusToApproved() {
+        Id me = UserInfo.getUserId();
+        Property__c property = makeProperty(makeBroker(me).Id);
+        Tour_Request__c request = makeRequest(property.Id, me);
+        insert request; // before-save flow stamps Realtor_User__c = me
+
+        request = [
+            SELECT Id, Status__c, Realtor_User__c
+            FROM Tour_Request__c
+            WHERE Id = :request.Id
+        ];
+        Assert.areEqual(
+            me,
+            request.Realtor_User__c,
+            'Before-save flow should have stamped the realtor.'
+        );
+
+        if (!approvalProcessIsActive()) {
+            // T-02 deployed state: process is inactive, so no lifecycle to run.
+            Assert.areEqual(
+                'Draft',
+                request.Status__c,
+                'With the approval process inactive the request stays in Draft.'
+            );
+            return;
+        }
+
+        Test.startTest();
+        Approval.ProcessSubmitRequest submit = new Approval.ProcessSubmitRequest();
+        submit.setObjectId(request.Id);
+        Approval.ProcessResult submitResult = Approval.process(submit);
+
+        Tour_Request__c afterSubmit = [
+            SELECT Status__c
+            FROM Tour_Request__c
+            WHERE Id = :request.Id
+        ];
+        Assert.areEqual(
+            'Pending Approval',
+            afterSubmit.Status__c,
+            'Submitting for approval should set Status = Pending Approval.'
+        );
+
+        Approval.ProcessWorkitemRequest approve = new Approval.ProcessWorkitemRequest();
+        approve.setAction('Approve');
+        approve.setWorkitemId(submitResult.getNewWorkitemIds()[0]);
+        Approval.process(approve);
+        Test.stopTest();
+
+        Tour_Request__c afterApprove = [
+            SELECT Status__c
+            FROM Tour_Request__c
+            WHERE Id = :request.Id
+        ];
+        Assert.areEqual(
+            'Approved',
+            afterApprove.Status__c,
+            'Approving should set Status = Approved.'
+        );
+    }
+
+    @isTest
+    static void rejectDrivesStatusToRejected() {
+        if (!approvalProcessIsActive()) {
+            return; // exercised live in T-03 once the process is active
+        }
+        Id me = UserInfo.getUserId();
+        Property__c property = makeProperty(makeBroker(me).Id);
+        Tour_Request__c request = makeRequest(property.Id, me);
+        insert request;
+
+        Test.startTest();
+        Approval.ProcessSubmitRequest submit = new Approval.ProcessSubmitRequest();
+        submit.setObjectId(request.Id);
+        Approval.ProcessResult submitResult = Approval.process(submit);
+
+        Approval.ProcessWorkitemRequest reject = new Approval.ProcessWorkitemRequest();
+        reject.setAction('Reject');
+        reject.setWorkitemId(submitResult.getNewWorkitemIds()[0]);
+        Approval.process(reject);
+        Test.stopTest();
+
+        Tour_Request__c afterReject = [
+            SELECT Status__c
+            FROM Tour_Request__c
+            WHERE Id = :request.Id
+        ];
+        Assert.areEqual(
+            'Rejected',
+            afterReject.Status__c,
+            'Rejecting should set Status = Rejected.'
+        );
+    }
+
+    @isTest
+    static void submitBulkRequestsDrivesAllToPending() {
+        Id me = UserInfo.getUserId();
+        Property__c property = makeProperty(makeBroker(me).Id);
+        List<Tour_Request__c> requests = new List<Tour_Request__c>();
+        for (Integer i = 0; i < 5; i++) {
+            requests.add(makeRequest(property.Id, me));
+        }
+        insert requests;
+
+        if (!approvalProcessIsActive()) {
+            for (Tour_Request__c tr : [
+                SELECT Status__c
+                FROM Tour_Request__c
+                WHERE Id IN :requests
+            ]) {
+                Assert.areEqual(
+                    'Draft',
+                    tr.Status__c,
+                    'With the process inactive bulk requests stay in Draft.'
+                );
+            }
+            return;
+        }
+
+        Test.startTest();
+        List<Approval.ProcessSubmitRequest> submits = new List<Approval.ProcessSubmitRequest>();
+        for (Tour_Request__c tr : requests) {
+            Approval.ProcessSubmitRequest submit = new Approval.ProcessSubmitRequest();
+            submit.setObjectId(tr.Id);
+            submits.add(submit);
+        }
+        Approval.process(submits);
+        Test.stopTest();
+
+        for (Tour_Request__c tr : [
+            SELECT Status__c
+            FROM Tour_Request__c
+            WHERE Id IN :requests
+        ]) {
+            Assert.areEqual(
+                'Pending Approval',
+                tr.Status__c,
+                'Every bulk-submitted request should be Pending Approval.'
+            );
+        }
+    }
+}

--- a/force-app/main/default/classes/TestTourRequestApproval.cls-meta.xml
+++ b/force-app/main/default/classes/TestTourRequestApproval.cls-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass
+    xmlns="urn:metadata.tooling.soap.sforce.com"
+    fqn="TestTourRequestApproval"
+>
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/email/unfiled$public/Tour_Request_Approved.email
+++ b/force-app/main/default/email/unfiled$public/Tour_Request_Approved.email
@@ -1,0 +1,11 @@
+Hi {!Receiving_User.FirstName},
+
+Good news — your tour request {!Tour_Request__c.Name} has been approved!
+
+Property: {!Tour_Request__c.Property__c}
+Requested date/time: {!Tour_Request__c.Requested_Date_Time__c}
+
+Your realtor will be in touch to confirm the details. We look forward to showing you the home.
+
+Thank you,
+The Dreamhouse Team

--- a/force-app/main/default/email/unfiled$public/Tour_Request_Approved.email-meta.xml
+++ b/force-app/main/default/email/unfiled$public/Tour_Request_Approved.email-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<EmailTemplate xmlns="http://soap.sforce.com/2006/04/metadata">
+    <available>true</available>
+    <encodingKey>UTF-8</encodingKey>
+    <name>Tour Request Approved</name>
+    <style>none</style>
+    <subject
+    >Your tour request {!Tour_Request__c.Name} has been approved</subject>
+    <type>text</type>
+    <uiType>Aloha</uiType>
+</EmailTemplate>

--- a/force-app/main/default/flows/Tour_Request_Set_Realtor.flow-meta.xml
+++ b/force-app/main/default/flows/Tour_Request_Set_Realtor.flow-meta.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <assignments>
+        <name>Set_Realtor_From_Property_Broker</name>
+        <label>Set Realtor From Property Broker</label>
+        <locationX>176</locationX>
+        <locationY>288</locationY>
+        <assignmentItems>
+            <assignToReference>$Record.Realtor_User__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Record.Property__r.Broker__r.Realtor_User__c</elementReference>
+            </value>
+        </assignmentItems>
+    </assignments>
+    <description
+    >Before-save: copies the property's broker's realtor User onto the tour request so approval can auto-route to that user.</description>
+    <environments>Default</environments>
+    <interviewLabel>Tour Request Set Realtor {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Tour Request Set Realtor</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Set_Realtor_From_Property_Broker</targetReference>
+        </connector>
+        <object>Tour_Request__c</object>
+        <recordTriggerType>CreateAndUpdate</recordTriggerType>
+        <triggerType>RecordBeforeSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/force-app/main/default/objects/Broker__c/fields/Realtor_User__c.field-meta.xml
+++ b/force-app/main/default/objects/Broker__c/fields/Realtor_User__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Realtor_User__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Realtor</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Brokers</relationshipLabel>
+    <relationshipName>Brokers</relationshipName>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/Tour_Request__c.object-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/Tour_Request__c.object-meta.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <actionOverrides>
+        <actionName>Accept</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>CancelEdit</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Clone</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Delete</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Edit</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>List</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>New</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>SaveEdit</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>Tab</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>View</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <enableActivities>true</enableActivities>
+    <enableBulkApi>true</enableBulkApi>
+    <enableFeeds>false</enableFeeds>
+    <enableHistory>true</enableHistory>
+    <enableReports>true</enableReports>
+    <enableSearch>true</enableSearch>
+    <enableSharing>true</enableSharing>
+    <enableStreamingApi>true</enableStreamingApi>
+    <label>Tour Request</label>
+    <nameField>
+        <displayFormat>TR-{0000}</displayFormat>
+        <label>Tour Request Number</label>
+        <trackHistory>false</trackHistory>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Tour Requests</pluralLabel>
+    <searchLayouts />
+    <sharingModel>ReadWrite</sharingModel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/Tour_Request__c/fields/Customer__c.field-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/fields/Customer__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Customer__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Customer</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Tour Requests (Customer)</relationshipLabel>
+    <relationshipName>Tour_Requests_Customer</relationshipName>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/fields/Notes__c.field-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/fields/Notes__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Notes__c</fullName>
+    <externalId>false</externalId>
+    <label>Notes</label>
+    <length>500</length>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/fields/Property__c.field-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/fields/Property__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Property__c</fullName>
+    <deleteConstraint>Restrict</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Property</label>
+    <referenceTo>Property__c</referenceTo>
+    <relationshipLabel>Tour Requests</relationshipLabel>
+    <relationshipName>Tour_Requests</relationshipName>
+    <required>true</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/fields/Realtor_User__c.field-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/fields/Realtor_User__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Realtor_User__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Realtor</label>
+    <referenceTo>User</referenceTo>
+    <relationshipLabel>Tour Requests (Realtor)</relationshipLabel>
+    <relationshipName>Tour_Requests_Realtor</relationshipName>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/fields/Requested_Date_Time__c.field-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/fields/Requested_Date_Time__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Requested_Date_Time__c</fullName>
+    <externalId>false</externalId>
+    <label>Requested Date/Time</label>
+    <required>true</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/fields/Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/fields/Status__c.field-meta.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Status__c</fullName>
+    <externalId>false</externalId>
+    <label>Status</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Draft</fullName>
+                <default>true</default>
+                <label>Draft</label>
+            </value>
+            <value>
+                <fullName>Pending Approval</fullName>
+                <default>false</default>
+                <label>Pending Approval</label>
+            </value>
+            <value>
+                <fullName>Approved</fullName>
+                <default>false</default>
+                <label>Approved</label>
+            </value>
+            <value>
+                <fullName>Rejected</fullName>
+                <default>false</default>
+                <label>Rejected</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Tour_Request__c/validationRules/Customer_Required.validationRule-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/validationRules/Customer_Required.validationRule-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Customer_Required</fullName>
+    <active>true</active>
+    <description
+    >A tour request must always name a customer. Enforces D1 at the record level because a Lookup(User) cannot be marked required at the schema level.</description>
+    <errorConditionFormula>ISBLANK(Customer__c)</errorConditionFormula>
+    <errorDisplayField>Customer__c</errorDisplayField>
+    <errorMessage>Please select a customer for this tour request.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Tour_Request__c/validationRules/Submit_Requires_Realtor.validationRule-meta.xml
+++ b/force-app/main/default/objects/Tour_Request__c/validationRules/Submit_Requires_Realtor.validationRule-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Submit_Requires_Realtor</fullName>
+    <active>true</active>
+    <description
+    >A tour request cannot leave Draft (be submitted for approval) unless a realtor is assigned to approve it. Complements the approval process entry criteria with a friendly, user-facing guard.</description>
+    <errorConditionFormula
+    >AND(ISBLANK(Realtor_User__c), NOT(ISPICKVAL(Status__c, "Draft")))</errorConditionFormula>
+    <errorMessage
+    >This tour request has no realtor to approve it. A realtor is set automatically from the property's broker — pick a property whose broker has a realtor before submitting.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/permissionsets/dreamhouse.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/dreamhouse.permissionset-meta.xml
@@ -43,6 +43,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Broker__c.Realtor_User__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Broker__c.Picture__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -181,6 +186,26 @@
         <field>Property__c.Zip__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Tour_Request__c.Customer__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Tour_Request__c.Notes__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Tour_Request__c.Realtor_User__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Tour_Request__c.Status__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>dreamhouse</label>
     <objectPermissions>
@@ -201,6 +226,15 @@
         <object>Property__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Tour_Request__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
     <tabSettings>
         <tab>Broker__c</tab>
         <visibility>Visible</visibility>
@@ -219,6 +253,10 @@
     </tabSettings>
     <tabSettings>
         <tab>Settings</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
+        <tab>Tour_Request__c</tab>
         <visibility>Visible</visibility>
     </tabSettings>
 </PermissionSet>

--- a/force-app/main/default/tabs/Tour_Request__c.tab-meta.xml
+++ b/force-app/main/default/tabs/Tour_Request__c.tab-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <motif>Custom53: Bell</motif>
+</CustomTab>

--- a/force-app/main/default/workflows/Tour_Request__c.workflow-meta.xml
+++ b/force-app/main/default/workflows/Tour_Request__c.workflow-meta.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Workflow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <alerts>
+        <fullName>Tour_Request_Approved_Customer</fullName>
+        <description
+        >Notifies the customer that their tour request has been approved.</description>
+        <protected>false</protected>
+        <recipients>
+            <field>Customer__c</field>
+            <type>userLookup</type>
+        </recipients>
+        <senderType>CurrentUser</senderType>
+        <template>unfiled$public/Tour_Request_Approved</template>
+    </alerts>
+    <fieldUpdates>
+        <fullName>Set_Status_Approved</fullName>
+        <description
+        >Final-approval action: marks the tour request Approved.</description>
+        <field>Status__c</field>
+        <literalValue>Approved</literalValue>
+        <name>Set Status Approved</name>
+        <notifyAssignee>false</notifyAssignee>
+        <operation>Literal</operation>
+        <protected>false</protected>
+        <reevaluateOnChange>false</reevaluateOnChange>
+    </fieldUpdates>
+    <fieldUpdates>
+        <fullName>Set_Status_Pending_Approval</fullName>
+        <description
+        >Initial-submission action: marks the tour request Pending Approval.</description>
+        <field>Status__c</field>
+        <literalValue>Pending Approval</literalValue>
+        <name>Set Status Pending Approval</name>
+        <notifyAssignee>false</notifyAssignee>
+        <operation>Literal</operation>
+        <protected>false</protected>
+        <reevaluateOnChange>false</reevaluateOnChange>
+    </fieldUpdates>
+    <fieldUpdates>
+        <fullName>Set_Status_Rejected</fullName>
+        <description
+        >Final-rejection action: marks the tour request Rejected.</description>
+        <field>Status__c</field>
+        <literalValue>Rejected</literalValue>
+        <name>Set Status Rejected</name>
+        <notifyAssignee>false</notifyAssignee>
+        <operation>Literal</operation>
+        <protected>false</protected>
+        <reevaluateOnChange>false</reevaluateOnChange>
+    </fieldUpdates>
+</Workflow>


### PR DESCRIPTION
## Summary

Implements the **Property Tour Request & Approval** feature (spec: `docs/sf-app-architect/SPEC-tour-request-approval.md`). A customer (internal User) creates a `Tour_Request__c` on a property; automation stamps the property's realtor; the request routes through an approval process to that realtor; on approval the customer is emailed and the request is marked `Approved` (reject → `Rejected`).

Covers implementation tickets **T-01** and **T-02**. Activation and the live end-to-end walkthrough are **T-03** (human-controlled — not in this PR).

## T-01 — Data model + auto-populated realtor (`43b1f6d`)
- `Tour_Request__c` (AutoNumber `TR-{0000}`) + fields: `Property__c`, `Customer__c`, `Realtor_User__c`, `Status__c`, `Requested_Date_Time__c`, `Notes__c`
- `Broker__c.Realtor_User__c` lookup → User
- `Flow:Tour_Request_Set_Realtor` — before-save, copies `Property__r.Broker__r.Realtor_User__c` onto the request
- `PermissionSet:dreamhouse` extended (object + FLS; `Status__c`/`Realtor_User__c` read-only) + `CustomTab:Tour_Request__c`
- `SampleDataController` stamps `Realtor_User__c = UserInfo.getUserId()` on brokers
- Decisions: D1, D2, D5, D6

## T-02 — Approval routing, status lifecycle & confirmation email (`baff0b4`)
- `ApprovalProcess:Tour_Request_Approval` — ships **inactive**; approver via `relatedUserField=Realtor_User__c`; entry `Status=Draft AND Realtor_User__c not blank`; locks the record while pending; drives `Status` Pending Approval → Approved/Rejected
- `Workflow:Tour_Request__c` — 3 field updates + customer Email Alert (`userLookup` on `Customer__c`)
- `EmailTemplate:Tour_Request_Approved`
- `ValidationRule:Submit_Requires_Realtor` + `Customer_Required` (D1 record-level enforcement)
- `TestTourRequestApproval` — validation-rule + submit/approve/reject/bulk lifecycle tests
- Decisions: D3, D4

## Verification
- `npm run prettier`, `npm run lint` — clean
- `npm run test:unit` — 83/83
- `sf code-analyzer run` — only Low `ApexUnitTestClassShouldHaveRunAs` (matches existing test baseline)
- `sf project deploy start --dry-run --target-org dreamhouse` — **Succeeded**
- Apex tests in `dreamhouse` — pass (approval lifecycle asserts live once T-03 activates the process)

## Out of scope / follow-up
- **T-03**: set Email Deliverability = All email, activate the approval process, assign `PermissionSet:dreamhouse` to test users, run the live email walkthrough
- Production release (human-controlled per project config)